### PR TITLE
Fix failing multiprocessing UT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 the [PEP 440 version scheme](https://peps.python.org/pep-0440/#version-scheme).
 
+## [v0.6.1] - 2023-02-24
+## Fixed
+- A bug that prevented import context from being restored if an exception was raised. #1
+
 ## [v0.6.0] - 2023-01-04
 ## Changed
 - The `ipc_queue` argument name to `ipc_logger_queue`

--- a/serpentarium/plugin_wrapper.py
+++ b/serpentarium/plugin_wrapper.py
@@ -40,17 +40,16 @@ class PluginWrapper(NamedPluginMixin, MultiUsePlugin):
             return self.plugin.run(**kwargs)
 
         result = None
-        exception_raised = False
+        exception = None
         with self._plugin_import_context():
             try:
                 self.plugin = self._load_plugin()
                 result = self.plugin.run(**kwargs)
             except Exception as ex:
-                exception_raised = True
-                result = ex
+                exception = ex
 
-        if exception_raised:
-            raise result
+        if exception is not None:
+            raise exception
 
         return result
 

--- a/serpentarium/plugin_wrapper.py
+++ b/serpentarium/plugin_wrapper.py
@@ -39,8 +39,12 @@ class PluginWrapper(NamedPluginMixin, MultiUsePlugin):
         if self.plugin is not None:
             return self.plugin.run(**kwargs)
 
+        return self._run_in_isolated_context(**kwargs)
+
+    def _run_in_isolated_context(self, **kwargs) -> Any:
         result = None
         exception = None
+
         with self._plugin_import_context():
             try:
                 self.plugin = self._load_plugin()

--- a/serpentarium/plugin_wrapper.py
+++ b/serpentarium/plugin_wrapper.py
@@ -39,9 +39,20 @@ class PluginWrapper(NamedPluginMixin, MultiUsePlugin):
         if self.plugin is not None:
             return self.plugin.run(**kwargs)
 
+        result = None
+        exception_raised = False
         with self._plugin_import_context():
-            self.plugin = self._load_plugin()
-            return self.plugin.run(**kwargs)
+            try:
+                self.plugin = self._load_plugin()
+                result = self.plugin.run(**kwargs)
+            except Exception as ex:
+                exception_raised = True
+                result = ex
+
+        if exception_raised:
+            raise result
+
+        return result
 
     @contextlib.contextmanager
     def _plugin_import_context(self):

--- a/serpentarium/plugin_wrapper.py
+++ b/serpentarium/plugin_wrapper.py
@@ -36,6 +36,9 @@ class PluginWrapper(NamedPluginMixin, MultiUsePlugin):
         self._constructor_kwargs = kwargs
 
     def run(self, **kwargs) -> Any:
+        # After a plugin has been imported and run, it contains references to its own
+        # modules/dependencies. Therefore, we don't need to use `self._plugin_import_context()` in
+        # order to isolate after the initial run.
         if self.plugin is not None:
             return self.plugin.run(**kwargs)
 

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -50,15 +50,6 @@ def test_run_parameters(plugin_loader: PluginLoader):
 
 
 def test_multiprocessing_plugin_isolation(plugin_loader: PluginLoader):
-    """
-    NOTE: This test fails with the following error message:
-            def dump(obj, file, protocol=None):
-            '''Replacement for pickle.dump() using ForkingPickler.'''
-    >       ForkingPickler(file, protocol).dump(obj)
-    E       _pickle.PicklingError: Can't pickle <class 'serpentarium.multiprocessing_plugin.MultiprocessingPlugin'>: it's not the same object as serpentarium.multiprocessing_plugin.MultiprocessingPlugin
-
-    Manual testing passes. This will need more investigating to get it to pass as an automated test
-    """
     plugin1 = plugin_loader.load_multiprocessing_plugin(
         plugin_name="plugin1", reset_modules_cache=False
     )

--- a/tests/test_plugin_wrapper.py
+++ b/tests/test_plugin_wrapper.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 
 import pytest
@@ -23,3 +24,17 @@ def test_module_not_found_incorrect_plugin_name():
     with pytest.raises(ModuleNotFoundError):
         plugin = PluginWrapper(plugin_name="NONEXISTANT", plugin_directory=PLUGIN_DIR / "plugin1")
         plugin.run()
+
+
+def test_context_restored_on_exception():
+    import black  # Import black to ensure sys.modules differs from CLEAN_SYS_MODULES # noqa: F401
+
+    original_sys_modules = sys.modules.copy()
+
+    try:
+        plugin = PluginWrapper(plugin_name="NONEXISTANT", plugin_directory=PLUGIN_DIR / "plugin1")
+        plugin.run()
+    except Exception:
+        pass
+
+    assert sys.modules == original_sys_modules


### PR DESCRIPTION
Fixes #1 
Resolves https://github.com/guardicore/monkey/issues/2684

The culprit of the mulitprocessing plugin tests failing is actually the `test_module_not_found_incorrect_plugin_name()` test. If you remove it and run the test suite, everything passes. 

A detailed explanation can be found in the commit message of the first commit of this PR (https://github.com/guardicode/serpentarium/commit/f67b3fa6e3e29f2cc8a8c0bf73d7d711654c9c42).